### PR TITLE
Added additional verification of  value (when  is array)

### DIFF
--- a/action.php
+++ b/action.php
@@ -74,7 +74,7 @@ class action_plugin_publish extends DokuWiki_Action_Plugin {
         global $INFO;
         if(!$this->hlp->in_namespace($this->getConf('apr_namespaces'), $ID)) { return; }
         if($INFO['perm'] < AUTH_DELETE) { return true; }
-        if($ACT != 'save') { return true; }
+        if(($ACT != 'save') && (!array_key_exists ( 'save' , $ACT))) { return true; }
         if(!$event->data[3]) { return true; } # don't approve the doc being moved to archive
         if($_POST['approved']) {
             $data = pageinfo();


### PR DESCRIPTION
Just a small fix for an issue I have faced. When debugging and issue I have found that $ACT is an array $ACT = array('save'=>'Save') and not a 'save' string value.
