### PR TITLE
 Illegal string offset '_elem' in action.php on line 205 / 231

### DIFF
--- a/action.php
+++ b/action.php
@@ -252,10 +252,12 @@ class action_plugin_publish extends DokuWiki_Action_Plugin {
                       if($this->hlp->in_namespace($this->getConf('apr_namespaces'), $usename)) {
                           $meta = p_get_metadata($usename);
     
-                          if($meta['approval'][$meta['last_change']['date']]) {
-                            $event->data->_content[$member]['class'] = 'li approved_revision';
-                          }else{
-                            $event->data->_content[$member]['class'] = 'li unapproved_revision';
+                          if ( isset ( $meta['last_change']['date'] ) ) {
+                              if($meta['approval'][$meta['last_change']['date']]) {
+                                $event->data->_content[$member]['class'] = 'li approved_revision';
+                              }else{
+                                $event->data->_content[$member]['class'] = 'li unapproved_revision';
+                              }
                           }
                       }
                     }


### PR DESCRIPTION
CORRECTED solution: simple PHP break does not do the full job, we need to check all `$ref` items (a) for the whole foreach body concerning `handle_recent`, and (b) for the `if` clause that sets `$member` but not for the whole foreach body concerning `handle_revisions

See also https://www.dokuwiki.org/plugin:publish#error_when_using_the_old_revisions_view
