### PR TITLE
Fix Bad value for attribute href

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -350,8 +350,8 @@ class helper_plugin_publish extends DokuWiki_Plugin {
         if($rev1 == $rev2) {
             return '';
         }
-        $params = 'do=diff,rev2[0]=' . $rev1 . ',rev2[1]=' . $rev2 . ',difftype=sidebyside';
-        $difflink = wl($id, $params,true,'&');
+        $params = array('do' => 'diff', 'difftype' => 'sidebyside', 'rev2[0]' => $rev1, 'rev2[1]' => $rev2);
+        $difflink = wl($id, $params,true);
         return $difflink;
     }
 


### PR DESCRIPTION
W3C shows ```Error: Bad value http://server/wiki/page?do=diff&difftype=sidebyside&rev2[0]=1423241659&rev2[1]=1427454336 for attribute href on element a: Illegal character in query: not a URL code point.```

Fixes #55 

Changes:
- switched $params from string to array. For string, dokuwiki does a simple str_replace(), while for array buildURLparams() is called, which rawurlencode() the params. This fixes square brackets shown as illegal character.
- removed fourth parameter ```seperator``` to use default '&amp;' instead of unescaped '&'.