### PR TITLE
Translation update (de) and some typo fixes

### DIFF
--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -5,14 +5,14 @@
  *
  * @author Mark Prins <mprins@users.sf.net>
  */
-$lang['apr_namespaces']        = 'Namensräume auf die dieses Plugin angewendet werden soll';
+$lang['apr_namespaces']        = 'Namensräume, auf die dieses Plugin angewendet werden soll';
 $lang['no_apr_namespaces']     = 'Namensräume, auf die dieses Plugin <strong>nicht</strong> angewendet werden soll';
-$lang['number_of_approved']    = 'Anzahl der Benutzer die das Dokument prüfen müssen, damit es als bestätigt gilt.';
-$lang['hidereaderbanner']      = 'Verstecke Banner für Benutzern die nur das Leserecht haben';
-$lang['hide drafts']           = 'Verstecke unbestätigte Versionen vor Benutzern die nur das Leserecht haben.';
+$lang['number_of_approved']    = 'Anzahl der Benutzer, die das Dokument prüfen müssen, damit es als bestätigt gilt.';
+$lang['hidereaderbanner']      = 'Verstecke Banner vor Benutzern, die nur das Leserecht haben';
+$lang['hide drafts']           = 'Verstecke unbestätigte Versionen vor Benutzern, die nur das Leserecht haben.';
 $lang['hide_approved_banner']  = 'Verstecke Banner auf bestätigten Seiten.';
-$lang['author groups']         = 'Gruppen die drafts sehen können (mehrere mit Leerzeichen trennen)';
-$lang['internal note']         = 'Notiz auf nicht veröffentlichen Seiten';
-$lang['delete attic on first approve'] = 'Alter Versionen bei erster Bestätigung löschen';
+$lang['author groups']         = 'Gruppen, die Drafts sehen können (mehrere mit Leerzeichen trennen)';
+$lang['internal note']         = 'Notiz auf nicht veröffentlichten Seiten';
+$lang['delete attic on first approve'] = 'Alte Versionen bei erster Bestätigung löschen';
 
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -4,6 +4,7 @@
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  *
  * @author Mark Prins <mprins@users.sf.net>
+ * @author Carsten Perthel <carsten@cpesoft.com>
  */
 $lang['apr_namespaces']        = 'Namensräume, auf die dieses Plugin angewendet werden soll';
 $lang['no_apr_namespaces']     = 'Namensräume, auf die dieses Plugin <strong>nicht</strong> angewendet werden soll';
@@ -15,4 +16,6 @@ $lang['author groups']         = 'Gruppen, die Drafts sehen können (mehrere mit
 $lang['internal note']         = 'Notiz auf nicht veröffentlichten Seiten';
 $lang['delete attic on first approve'] = 'Alte Versionen bei erster Bestätigung löschen';
 
-
+$lang['send_mail_on_approve'] = 'Email senden, wenn eine Seite bestätigt wurde?';
+$lang['apr_mail_receiver'] = 'Standard Mailadresse für Änderungen. Wenn eingetragen, wird eine Email nach jeder Seitenänderung verschickt.';
+$lang['apr_approved_text'] = 'Standard Bestätigungs-Marker';


### PR DESCRIPTION
This pull request adds translations for keys 'send_mail_on_approve', 'apr_mail_receiver' and 'apr_approved_text' in de.
Additionally some typos and commas were fixed.