### PR TITLE
 Implement action to display/hide showrev warning.

### DIFF
--- a/action/handleshowrev.php
+++ b/action/handleshowrev.php
@@ -1,0 +1,35 @@
+<?php
+
+if(!defined('DOKU_INC')) die();
+
+class action_plugin_publish_handleshowrev extends DokuWiki_Action_Plugin {
+
+    /**
+     * @var helper_plugin_publish
+     */
+    private $hlp;
+
+    function __construct() {
+        $this->hlp = plugin_load('helper','publish');
+    }
+
+    function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('HTML_SHOWREV_OUTPUT', 'BEFORE', $this, 'handle_showrev', array());
+    }
+
+    /**
+     * @param Doku_Event $event
+     * @param array $param
+     */
+    function handle_showrev(Doku_Event &$event, $param) {
+        if (!$this->hlp->isActive()) {
+            return;
+        }
+        
+        if ($this->getConf('hide_showrev')) {
+            $event->preventDefault();    
+        }
+        
+        return;
+    }
+}

--- a/conf/default.php
+++ b/conf/default.php
@@ -6,6 +6,7 @@ $conf['number_of_approved'] = 1;
 $conf['hidereaderbanner'] = 0;
 $conf['hide drafts'] = 0;
 $conf['hide_approved_banner'] = 0;
+$conf['hide_showrev'] = 0;
 $conf['author groups'] = '';
 $conf['internal note'] = '';
 $conf['delete attic on first approve'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,6 +6,7 @@ $meta['number_of_approved'] = array('numeric', '_min' => 1);
 $meta['hide drafts'] = array('onoff');
 $meta['hidereaderbanner'] = array('onoff');
 $meta['hide_approved_banner'] = array('onoff');
+$meta['hide_showrev'] = array('onoff');
 $meta['author groups'] = array('string');
 $meta['internal note'] = array('string');
 $meta['delete attic on first approve'] = array('onoff');

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -12,6 +12,7 @@ $lang['number_of_approved']    = 'Anzahl der Benutzer, die das Dokument prüfen 
 $lang['hidereaderbanner']      = 'Verstecke Banner vor Benutzern, die nur das Leserecht haben';
 $lang['hide drafts']           = 'Verstecke unbestätigte Versionen vor Benutzern, die nur das Leserecht haben.';
 $lang['hide_approved_banner']  = 'Verstecke Banner auf bestätigten Seiten.';
+$lang['hide_showrev']          = 'Verstecke showrev Warnung';
 $lang['author groups']         = 'Gruppen, die Drafts sehen können (mehrere mit Leerzeichen trennen)';
 $lang['internal note']         = 'Notiz auf nicht veröffentlichten Seiten';
 $lang['delete attic on first approve'] = 'Alte Versionen bei erster Bestätigung löschen';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -6,6 +6,7 @@ $lang['number_of_approved'] = 'Number of users needed to approve a page.';
 $lang['hidereaderbanner'] = 'Hide banner to read only users';
 $lang['hide drafts'] = 'Hide drafts to read only users';
 $lang['hide_approved_banner']  = 'Hide banner on approved pages';
+$lang['hide_showrev']  = 'Hide showrev warning';
 $lang['author groups'] = 'Groups that can see drafts (separate by blank)';
 $lang['internal note'] = 'Note on unapproved pages';
 $lang['delete attic on first approve'] = 'Delete attic on first approve';


### PR DESCRIPTION
This prevents or allows the HTML_SHOWREV_OUTPUT event to occur based on the config option setting for 'hide_showrev'.
Fixes #16 