### PR TITLE
Approve namespace

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -421,4 +421,14 @@ class helper_plugin_publish extends DokuWiki_Plugin {
         return false;
     }
 
+    public function removeSubnamespacePages ($pages, $namespace) {
+        $cleanpages = array();
+        foreach ($pages as $page) {
+            if (getNS($page[0]) == $namespace) {
+                $cleanpages[] = $page;
+            }
+        }
+        return $cleanpages;
+    }
+
 }

--- a/helper.php
+++ b/helper.php
@@ -369,4 +369,56 @@ class helper_plugin_publish extends DokuWiki_Plugin {
         return $difflink;
     }
 
+    function getPagesFromNamespace($namespace) {
+        global $conf;
+        $dir = $conf['datadir'] . '/' . str_replace(':', '/', $namespace);
+        $pages = array();
+        search($pages, $dir, array($this,'_search_helper'), array($namespace, $this->getConf('apr_namespaces'),
+                                                                  $this->getConf('no_apr_namespaces')));
+        return $pages;
+    }
+
+    /**
+     * search callback function
+     *
+     * filter out pages which can't be approved by the current user
+     * then check if they need approving
+     */
+    function _search_helper(&$data, $base, $file, $type, $lvl, $opts) {
+        $ns = $opts[0];
+        $valid_ns = $opts[1];
+        $invalid_ns = $opts[2];
+
+        if ($type == 'd') {
+            return $this->is_dir_valid($valid_ns, $ns . ':' . str_replace('/', ':', $file));
+        }
+
+        if (!preg_match('#\.txt$#', $file)) {
+            return false;
+        }
+
+        $id = pathID($ns . $file);
+        if (!empty($valid_ns) && !$this->in_namespace($valid_ns, $id)) {
+            return false;
+        }
+
+        if (!empty($invalid_ns) && $this->in_namespace($invalid_ns, $id)) {
+            return false;
+        }
+
+        if (auth_quickaclcheck($id) < AUTH_DELETE) {
+            return false;
+        }
+
+        $meta = $this->getMeta($id);
+        if ($this->isCurrentRevisionApproved($id)) {
+
+            // Already approved
+            return false;
+        }
+
+        $data[] = array($id, $meta['approval'], $meta['last_change']['date']);
+        return false;
+    }
+
 }

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -34,3 +34,5 @@ $lang['approve action']        = 'Dokument bestätigen';
 $lang['apr_do_approve'] = 'Bestätigen';
 $lang['apr_mail_subject'] = 'Neuer Vorschlag';
 $lang['apr_mail_app_subject'] = 'Vorschlag bestätigt';
+
+$lang['approveNS'] = 'Namensraum bestätigen';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -36,3 +36,5 @@ $lang['mail_invalid'] = 'One of email adresses entered for change notifications 
 $lang['apr_do_approve'] = 'Approve';
 $lang['apr_mail_subject'] = 'new suggestion';
 $lang['apr_mail_app_subject'] = 'suggestion approved';
+
+$lang['approveNS'] = 'Approve namespace';

--- a/script.js
+++ b/script.js
@@ -17,3 +17,30 @@ function approval_checkbox(text) {
 
   return true;
 }
+
+
+jQuery( document ).ready(function () {
+    jQuery('button.publish__approveNS').click(function(evt){
+        var $_this = jQuery(this);
+        var namespace = $_this.attr('ns');
+        jQuery.post(
+            DOKU_BASE + 'lib/exe/ajax.php',
+            {
+                call: 'plugin_publish_approveNS',
+                namespace: namespace
+            },
+            function(data) {
+                $_this.parent().parent().siblings('tr.apr_table').each(function(index) {
+                        var id = jQuery(this).find('a').first().text();
+                        var pageNamespace = id.substr(0,id.lastIndexOf(':'));
+                        if (pageNamespace === namespace) {
+                            jQuery(this).hide('slow');
+                        }
+                    }
+                );
+                $_this.parent().parent().hide('slow');
+            },
+            'json'
+        );
+    });
+});

--- a/style.css
+++ b/style.css
@@ -68,5 +68,5 @@ div.approval span span.approval_date {
 }
 
 button.publish__approveNS {
-    float: right;
+    float: left;
 }

--- a/style.css
+++ b/style.css
@@ -66,3 +66,7 @@ table.apr_table tr.apr_ns td {
 div.approval span span.approval_date {
   display: inline;
 }
+
+button.publish__approveNS {
+    float: right;
+}

--- a/syntax.php
+++ b/syntax.php
@@ -88,7 +88,9 @@ class syntax_plugin_publish extends DokuWiki_Syntax_Plugin {
                 $renderer->doc .= wl($this_ns . ':' . $this->getConf('start'));
                 $renderer->doc .= '">';
                 $renderer->doc .= $name_ns;
-                $renderer->doc .= '</a></td></tr>';
+                $renderer->doc .= '</a> ';
+                $renderer->doc .= '<button class="publish__approveNS" type="button" ns="' . $name_ns .'">' . $this->getLang('approveNS') . '</button>';
+                $renderer->doc .= '</td></tr>';
                 $working_ns = $this_ns;
             }
 

--- a/syntax.php
+++ b/syntax.php
@@ -59,7 +59,7 @@ class syntax_plugin_publish extends DokuWiki_Syntax_Plugin {
 
         $namespace = cleanID(getNS($namespace . ":*"));
 
-        $pages = $this->getPagesFromNamespace($namespace);
+        $pages = $this->hlp->getPagesFromNamespace($namespace);
 
         if(count($pages) == 0) {
             $renderer->doc .= '<p class="apr_none">' . $this->getLang('apr_p_none') . '</p>';
@@ -127,57 +127,7 @@ class syntax_plugin_publish extends DokuWiki_Syntax_Plugin {
         return true;
     }
 
-    function getPagesFromNamespace($namespace) {
-        global $conf;
-        $dir = $conf['datadir'] . '/' . str_replace(':', '/', $namespace);
-        $pages = array();
-        search($pages, $dir, array($this,'_search_helper'), array($namespace, $this->getConf('apr_namespaces'),
-                                                                  $this->getConf('no_apr_namespaces')));
-        return $pages;
-    }
 
-    /**
-     * search callback function
-     *
-     * filter out pages which can't be approved by the current user
-     * then check if they need approving
-     */
-    function _search_helper(&$data, $base, $file, $type, $lvl, $opts) {
-        $ns = $opts[0];
-        $valid_ns = $opts[1];
-        $invalid_ns = $opts[2];
-
-        if ($type == 'd') {
-            return $this->hlp->is_dir_valid($valid_ns, $ns . ':' . str_replace('/', ':', $file));
-        }
-
-        if (!preg_match('#\.txt$#', $file)) {
-            return false;
-        }
-
-        $id = pathID($ns . $file);
-        if (!empty($valid_ns) && !$this->hlp->in_namespace($valid_ns, $id)) {
-            return false;
-        }
-
-        if (!empty($invalid_ns) && $this->hlp->in_namespace($invalid_ns, $id)) {
-            return false;
-        }
-
-        if (auth_quickaclcheck($id) < AUTH_DELETE) {
-            return false;
-        }
-
-        $meta = $this->hlp->getMeta($id);
-        if ($this->hlp->isCurrentRevisionApproved($id)) {
-
-            // Already approved
-            return false;
-        }
-
-        $data[] = array($id, $meta['approval'], $meta['last_change']['date']);
-        return false;
-    }
 
     /**
      * Custom sort callback


### PR DESCRIPTION
Add a button to the overview generated by the `[APPROVALS]` tag to approve all pages directly within a namespace.