### PR TITLE
Add self-approve ability

### DIFF
--- a/_test/publish.test.php
+++ b/_test/publish.test.php
@@ -44,7 +44,7 @@ class approvel_test extends DokuWikiTest {
     public function test_unaprroved_banner_exists() {
         saveWikiText('foo', 'bar', 'foobar');
         $request = new TestRequest();
-        $response = $request->get(array('id' => 'foo'), '/doku.php?id=foo');
+        $response = $request->get(array(), '/doku.php?id=foo');
         $this->assertTrue(
             strpos($response->getContent(), '<div class="approval approved_no">') !== false,
             'The "not approved banner" is missing on a page which has not yet been aprroved with standard config.'
@@ -56,6 +56,8 @@ class approvel_test extends DokuWikiTest {
      * @coversNothing
      */
     public function test_aprroval_succesful() {
+        global $conf;
+        $conf['plugin']['publish']['auto_self_approve'] = 0;
         saveWikiText('foo', 'bar', 'foobar');
         $request = new TestRequest();
         $response = $request->get(array(), '/doku.php?id=foo&publish_approve=1');
@@ -81,6 +83,21 @@ class approvel_test extends DokuWikiTest {
             strpos($response->getContent(), '<div class="approval') === false,
             'The approved banner is still showing even so it is supposed not to show.'
         );
+    }
 
+    /**
+     * @coversNothing
+     */
+    public function test_self_aprrove() {
+        global $conf;
+        $conf['plugin']['publish']['auto_self_approve'] = 1;
+        saveWikiText('foo', 'bar', 'foobar');
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo');
+
+        $this->assertTrue(
+            strpos($response->getContent(), '<div class="approval approved_yes') === false,
+            'Approving a page automatically failed.'
+        );
     }
 }

--- a/action/mail.php
+++ b/action/mail.php
@@ -25,7 +25,7 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
 
     public function register(Doku_Event_Handler $controller) {
 
-        $controller->register_hook('IO_WIKIPAGE_WRITE', 'AFTER', $this, 'send_change_mail', array());
+        $controller->register_hook('IO_WIKIPAGE_WRITE', 'AFTER', $this, 'send_change_mail', array(), 1000);
     }
 
     /**

--- a/conf/default.php
+++ b/conf/default.php
@@ -6,6 +6,7 @@ $conf['number_of_approved'] = 1;
 $conf['hidereaderbanner'] = 0;
 $conf['hide drafts'] = 0;
 $conf['hide_approved_banner'] = 0;
+$conf['auto_self_approve'] = 0;
 $conf['author groups'] = '';
 $conf['internal note'] = '';
 $conf['delete attic on first approve'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,6 +6,7 @@ $meta['number_of_approved'] = array('numeric', '_min' => 1);
 $meta['hide drafts'] = array('onoff');
 $meta['hidereaderbanner'] = array('onoff');
 $meta['hide_approved_banner'] = array('onoff');
+$meta['auto_self_approve'] = array('onoff');
 $meta['author groups'] = array('string');
 $meta['internal note'] = array('string');
 $meta['delete attic on first approve'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -6,6 +6,7 @@ $lang['number_of_approved'] = 'Number of users needed to approve a page.';
 $lang['hidereaderbanner'] = 'Hide banner to read only users';
 $lang['hide drafts'] = 'Hide drafts to read only users';
 $lang['hide_approved_banner']  = 'Hide banner on approved pages';
+$lang['auto_self_approve']  = 'Self approve if possible when submitting edit';
 $lang['author groups'] = 'Groups that can see drafts (separate by blank)';
 $lang['internal note'] = 'Note on unapproved pages';
 $lang['delete attic on first approve'] = 'Delete attic on first approve';


### PR DESCRIPTION
Automatically approve changes with permission, with a new option `$conf['plugin']['publish']['auto_self_approve']` (default is OFF).

Unit test available (Has been tested on browser, but unit test not run yet).