### PR TITLE
Check user permission based on REV instead of ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 php:
-  - "5.7"
+  - "nightly"
+  - "7.2"
+  - "7.1"
+  - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
 env:
   - DOKUWIKI=master
   - DOKUWIKI=stable

--- a/_test/publish.test.php
+++ b/_test/publish.test.php
@@ -83,13 +83,7 @@ class approvel_test extends DokuWikiTest {
         );
     }
 
-    /**
-     * @coversNothing
-     */
-    public function test_show_expected_revision(){
-        global $conf;
-        $conf['plugin']['publish']['hide drafts'] = 1;
-
+    private function _prepare_revisions_and_test_common(){
         // nothing, @admin should see 404
         $request = new TestRequest();
         $response = $request->get(array(), '/doku.php?id=nonexist');
@@ -102,7 +96,7 @@ class approvel_test extends DokuWikiTest {
             'Visiting a non-exist page did not return notFound message.'
         );
 
-        // one approved and one draft
+        // init one approved and one draft
         saveWikiText('foo', 'This should get APPROVED', 'approved');
         $request = new TestRequest();
         $response = $request->get(array(), '/doku.php?id=foo&publish_approve=1');
@@ -112,7 +106,12 @@ class approvel_test extends DokuWikiTest {
         );
 
         saveWikiText('foo', 'This should be a DRAFT', 'draft');
+        $draft_rev = @filemtime(wikiFN('foo'));
 
+        // draft-only page
+        saveWikiText('draft_only', 'This should be a DRAFT', 'draft');
+
+        // a user with AUTH_EDIT or better will see the latest revision of a page
         // @admin should see the draft
         $request = new TestRequest();
         $response = $request->get(array(), '/doku.php?id=foo');
@@ -121,11 +120,11 @@ class approvel_test extends DokuWikiTest {
             'Visiting a page did not return in show mode.'
         );
         $this->assertTrue(
-            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            strpos($response->getContent(), 'This should be a DRAFT') !== false,
             'Visiting a page with draft did not return draft revision.'
         );
 
-        // @ALL should see approved revision
+        // switch to @ALL - AUTH_READ
         global $USERINFO;
         $USERINFO = null;
 
@@ -134,6 +133,7 @@ class approvel_test extends DokuWikiTest {
 
         $_SERVER['REMOTE_USER'] = null;
 
+        // @ALL should see approved revision
         $request = new TestRequest();
         $response = $request->get(array(), '/doku.php?id=foo');
         $this->assertTrue(
@@ -141,8 +141,90 @@ class approvel_test extends DokuWikiTest {
             'Visiting a page did not return in show mode.'
         );
         $this->assertTrue(
-            strpos($response->getContent(), 'This should get APPROVED') === false,
-            'Visiting a page with draft in visitor mode did not return approved revision.'
+            strpos($response->getContent(), 'This should get APPROVED') !== false,
+            'Visiting a page with draft with AUTH_READ did not return approved revision.'
+        );
+
+        return $draft_rev;
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_expected_revision(){
+        global $conf;
+
+        $draft_rev = $this->_prepare_revisions_and_test_common();
+
+        // someone with only AUTH_READ will see the latest approved revision by default (unless there isn't one)
+        // page with no approved revision: show draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=draft_only');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a draft-only page did not return in show mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') !== false,
+            'Visiting a draft-only page with AUTH_READ did not return draft revision.'
+        );
+
+        // all users with AUTH_READ or better can view any revision of a page if they specifically request it – whether or not it is approved
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo&rev='.$draft_rev);
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a draft revision did not return in show mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft revision with AUTH_READ did not return draft content.'
+        );
+
+        // nothing, @ALL should see 404
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=nonexist');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a non-exist page returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'notFound') !== false,
+            'Visiting a non-exist page did not return notFound message.'
+        );
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_expected_revision_hide_drafts(){
+        global $conf;
+        $conf['plugin']['publish']['hide drafts'] = 1;
+
+        $draft_rev = $this->_prepare_revisions_and_test_common();
+
+        // page with no approved revision: hide draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=draft_only');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_denied') !== false,
+            'Visiting a draft-only page with hide_drafts on did not return in denied mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft-only page with hide_drafts on with AUTH_READ returns draft content.'
+        );
+
+        // specifically request revision: without approval permission, deny it
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo&rev='.$draft_rev);
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_denied') !== false,
+            'Visiting a draft-only page did not return in denied mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft revision with hide_drafts on with AUTH_READ returns draft content.'
         );
 
         // nothing, @ALL should see 404

--- a/_test/publish.test.php
+++ b/_test/publish.test.php
@@ -81,6 +81,80 @@ class approvel_test extends DokuWikiTest {
             strpos($response->getContent(), '<div class="approval') === false,
             'The approved banner is still showing even so it is supposed not to show.'
         );
+    }
 
+    /**
+     * @coversNothing
+     */
+    public function test_show_expected_revision(){
+        global $conf;
+        $conf['plugin']['publish']['hide drafts'] = 1;
+
+        // nothing, @admin should see 404
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=nonexist');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a non-exist page returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'notFound') !== false,
+            'Visiting a non-exist page did not return notFound message.'
+        );
+
+        // one approved and one draft
+        saveWikiText('foo', 'This should get APPROVED', 'approved');
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo&publish_approve=1');
+        $this->assertTrue(
+            strpos($response->getContent(), '<div class="approval approved_yes">') !== false,
+            'Approving a page failed with standard options.'
+        );
+
+        saveWikiText('foo', 'This should be a DRAFT', 'draft');
+
+        // @admin should see the draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a page did not return in show mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a page with draft did not return draft revision.'
+        );
+
+        // @ALL should see approved revision
+        global $USERINFO;
+        $USERINFO = null;
+
+        global $default_server_vars;
+        $default_server_vars['REMOTE_USER'] = null; //Hack until Issue splitbrain/dokuwiki#1099 is fixed
+
+        $_SERVER['REMOTE_USER'] = null;
+
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a page did not return in show mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should get APPROVED') === false,
+            'Visiting a page with draft in visitor mode did not return approved revision.'
+        );
+
+        // nothing, @ALL should see 404
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=nonexist');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a non-exist page returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'notFound') !== false,
+            'Visiting a non-exist page did not return notFound message.'
+        );
     }
 }


### PR DESCRIPTION
with `hide_draft` on, DokuWiki should show notFound message or approved version correctly, but current code does:
- notFound -> denied
- (maybe) page with draft -> denied

For details try the unit test. This patch should fix this.