### PR TITLE
Don't color recent items on which plugin is disabled

### DIFF
--- a/action/recent.php
+++ b/action/recent.php
@@ -41,6 +41,10 @@ class action_plugin_publish_recent extends DokuWiki_Action_Plugin {
                 continue;
             }
 
+            if (!$this->hlp->isActive($id)) {
+                continue;
+            }
+
             if ($this->hlp->isCurrentRevisionApproved($id)) {
                 $event->data->_content[$parent]['class'] .= ' approved_revision';
             } else {


### PR DESCRIPTION
Make behavior same on `revision` and `recent`.