### PR TITLE
Fix .travis.yml (remove not testable versions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 php:
-  - "5.7"
+  - "nightly"
+  - "7.2"
+  - "7.1"
+  - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
 env:
   - DOKUWIKI=master
-  - DOKUWIKI=stable
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
 script: cd _test && phpunit --stderr --group plugin_publish


### PR DESCRIPTION
Currently the default options for Travis CI [fails a lot](https://travis-ci.org/phy25/dokuwiki-plugin-publish/builds/319654452). This patch makes Travis CI be able to [run correctly again](https://travis-ci.org/phy25/dokuwiki-plugin-publish/builds/321403595).