### PR TITLE
Use core function to display denied message (with login box)

### DIFF
--- a/action/hide.php
+++ b/action/hide.php
@@ -41,7 +41,7 @@ class action_plugin_publish_hide extends DokuWiki_Action_Plugin {
         $event->preventDefault();
         $event->stopPropagation();
 
-        print p_locale_xhtml('denied');
+        html_denied();
     }
 
     function hidePage(Doku_Event &$event, $params) {


### PR DESCRIPTION
This is a bug: The current denial message is not consistent with core. It lacks a login box (if login is necessary). This patch solves the issue.