### PR TITLE
Add revision display tests and fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 php:
-  - "5.7"
+  - "nightly"
+  - "7.2"
+  - "7.1"
+  - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
 env:
   - DOKUWIKI=master
-  - DOKUWIKI=stable
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
 script: cd _test && phpunit --stderr --group plugin_publish

--- a/_test/publish.test.php
+++ b/_test/publish.test.php
@@ -8,6 +8,7 @@
  * @group plugins
  * @group integrationtests
  * @author Michael Große <grosse@cosmocode.de>
+ * @author Phy25 <git@phy25.com>
  */
 class approvel_test extends DokuWikiTest {
 
@@ -34,8 +35,19 @@ class approvel_test extends DokuWikiTest {
         $conf['useacl']    = 1;
         $conf['superuser'] = '@admin';
         $AUTH_ACL = array(
-            '*                     @ALL        4',
-            '*                     @admin     16',);
+            '*                     @ALL        1',  // READ only
+            '*                     @author     4',  // EDIT
+            '*                     @admin     16',);// DELETE
+    }
+
+    private function logout(){
+        global $USERINFO;
+        $USERINFO = null;
+
+        global $default_server_vars;
+        $default_server_vars['REMOTE_USER'] = null; //Hack until Issue splitbrain/dokuwiki#1099 is fixed
+
+        $_SERVER['REMOTE_USER'] = null;
     }
 
     /**
@@ -81,6 +93,251 @@ class approvel_test extends DokuWikiTest {
             strpos($response->getContent(), '<div class="approval') === false,
             'The approved banner is still showing even so it is supposed not to show.'
         );
+    }
 
+    private function _prepare_pub_draft_revisions_and_test_common($test_namespace = false){
+        // init one approved and one draft
+        saveWikiText('foo', 'This should get APPROVED', 'approved');
+
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo&publish_approve');
+        $this->assertTrue(
+            strpos($response->getContent(), '<div class="approval approved_yes">') !== false,
+            'Approving a page failed with standard options.'
+        );
+
+        sleep(1); // create a different timestamp
+        saveWikiText('foo', 'This should be a DRAFT', 'draft');
+        $draft_rev = @filemtime(wikiFN('foo'));
+
+        // a user with AUTH_EDIT or better will see the latest revision of a page
+        // @admin should see the draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') === false,
+            'Visiting a page with draft with @admin returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') !== false,
+            'Visiting a page with draft with @admin did not return draft revision.'
+        );
+
+        // switch to @ALL - AUTH_READ
+        $this->logout();
+
+        // @ALL should see approved revision
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') === false,
+            'Visiting a page with draft with AUTH_READ returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should get APPROVED') !== false,
+            'Visiting a page with draft with AUTH_READ did not return approved revision.'
+        );
+
+        return $draft_rev;
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_draft_only_revision(){
+        // draft-only page
+        saveWikiText('draft_only', 'This should be a DRAFT', 'draft');
+
+        // switch to @ALL - AUTH_READ
+        $this->logout();
+
+        // someone with only AUTH_READ will see the latest approved revision by default (unless there isn't one)
+        // page with no approved revision: show draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=draft_only');
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a draft-only page did not return in show mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') !== false,
+            'Visiting a draft-only page with AUTH_READ did not return draft revision.'
+        );
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_draft_only_revision_hide_drafts(){
+        global $conf;
+        $conf['plugin']['publish']['hide drafts'] = 1;
+
+        // draft-only page
+        saveWikiText('draft_only', 'This should be a DRAFT', 'draft');
+
+        // switch to @ALL - AUTH_READ
+        $this->logout();
+
+        // page with no approved revision: hide draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=draft_only');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') !== false,
+            'Visiting a draft-only page with hide_drafts on did not return in denied mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft-only page with hide_drafts on with AUTH_READ returns draft content.'
+        );
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_draft_only_revision_hide_drafts_apr_namespaces(){
+        global $conf;
+        $conf['plugin']['publish']['hide drafts'] = 1;
+        $conf['plugin']['publish']['apr_namespaces'] = 'apr';
+
+        // draft-only page
+        saveWikiText('apr:draft', 'This should be a DRAFT', 'apr:draft');
+        saveWikiText('noapr:draft', 'This should not be applied', 'noapr:draft');
+
+        // switch to @ALL - AUTH_READ
+        $this->logout();
+
+        // unaffected page
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=noapr:draft');
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should not be applied') !== false,
+            'Pages outside apr_namespaces is affected by the plugin'
+        );
+
+        // page with no approved revision: hide draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=apr:draft');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') !== false,
+            'Visiting a draft-only page with hide_drafts on did not return in denied mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft-only page with hide_drafts on with AUTH_READ returns draft content.'
+        );
+
+        // switch to @ALL - AUTH_READ
+        $this->logout();
+
+        // page with no approved revision: hide draft
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=apr:draft');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') !== false,
+            'Visiting a draft-only page with hide_drafts on did not return in denied mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft-only page with hide_drafts on with AUTH_READ returns draft content.'
+        );
+
+        // unaffected page
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=noapr:draft');
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should not be applied') !== false
+        );
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_expected_revision(){
+        $draft_rev = $this->_prepare_pub_draft_revisions_and_test_common();
+
+        // all users with AUTH_READ or better can view any revision of a page if they specifically request it – whether or not it is approved
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo&rev='.$draft_rev);
+        $this->assertTrue(
+            strpos($response->getContent(), 'mode_show') !== false,
+            'Visiting a draft revision did not return in show mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') !== false,
+            'Visiting a draft revision with AUTH_READ did not return draft content.'
+        );
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function test_show_expected_revision_hide_drafts(){
+        global $conf;
+        $conf['plugin']['publish']['hide drafts'] = 1;
+
+        $draft_rev = $this->_prepare_pub_draft_revisions_and_test_common();
+
+        // specifically request revision: without approval permission, the best is to deny it
+        // but the current code redirect it to
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=foo&rev='.$draft_rev);
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') !== false,
+            'Visiting a draft revision with hide_drafts on did not return in denied mode.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'This should be a DRAFT') === false,
+            'Visiting a draft revision with hide_drafts on with AUTH_READ returns draft content.'
+        );
+    }
+
+    private function _test_correct_404(){
+        // nothing, @admin should see 404
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=apr:nonexist');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') === false,
+            'Visiting a non-exist page with admin returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'notFound') !== false,
+            'Visiting a non-exist page with admin did not return notFound message.'
+        );
+
+        // switch to @ALL - AUTH_READ
+        $this->logout();
+
+        // nothing, @ALL should see 404
+        $request = new TestRequest();
+        $response = $request->get(array(), '/doku.php?id=apr:nonexist');
+        $this->assertTrue(
+            strpos($response->getContent(), 'denied') === false,
+            'Visiting a non-exist page without login returns denied message.'
+        );
+        $this->assertTrue(
+            strpos($response->getContent(), 'notFound') !== false,
+            'Visiting a non-exist page without login did not return notFound message.'
+        );
+    }
+
+    public function test_correct_404(){
+        $this->_test_correct_404();
+    }
+
+    public function test_correct_404_hide_drafts(){
+        $conf['plugin']['publish']['hide drafts'] = 1;
+        $this->_test_correct_404();
+    }
+
+    public function test_correct_404_hide_drafts_apr_namespaces(){
+        $conf['plugin']['publish']['hide drafts'] = 1;
+        $conf['plugin']['publish']['apr_namespaces'] = 'apr';
+        $this->_test_correct_404();
+    }
+
+    public function test_correct_404_hide_drafts_no_apr_namespaces(){
+        $conf['plugin']['publish']['hide drafts'] = 1;
+        $conf['plugin']['publish']['no_apr_namespaces'] = 'noapr';
+        $this->_test_correct_404();
     }
 }

--- a/action/start.php
+++ b/action/start.php
@@ -22,6 +22,7 @@ class action_plugin_publish_start extends DokuWiki_Action_Plugin {
         global $REV;
         global $INFO;
         global $ID;
+        global $INPUT;
 
         if ($ACT !== 'show') {
             return;

--- a/action/start.php
+++ b/action/start.php
@@ -44,7 +44,8 @@ class action_plugin_publish_start extends DokuWiki_Action_Plugin {
             return;
         }
 
-        if (!$this->hlp->isCurrentRevisionApproved()) {
+        if (!$this->hlp->isCurrentRevisionApproved() && !$INPUT->has('rev')){
+            // if rev is present, no redirect
             $latestApproved = $this->hlp->getLatestApprovedRevision();
             if ($latestApproved) {
                 $REV = $latestApproved;

--- a/helper.php
+++ b/helper.php
@@ -286,6 +286,7 @@ class helper_plugin_publish extends DokuWiki_Plugin {
     }
 
     function isHidden($id = null) {
+        // if it is false, everyone can see drafts
         if (!$this->getConf('hide drafts')) {
             return false;
         }
@@ -299,13 +300,10 @@ class helper_plugin_publish extends DokuWiki_Plugin {
             return false;
         }
 
-        if ($this->getLatestApprovedRevision($id)) {
-            return false;
-        }
         return true;
     }
 
-    function isHiddenForUser($id = null) {
+    function isHiddenForUser($id = null, $rev = null) {
         if (!$this->isHidden($id)) {
             return false;
         }
@@ -313,6 +311,17 @@ class helper_plugin_publish extends DokuWiki_Plugin {
         if ($id == null) {
             global $ID;
             $id = $ID;
+            if ($rev == null){
+                global $REV;
+                $rev = $REV;
+            }
+        }
+
+        $revlist = $this->getSortedApprovedRevisions($id);
+        if($rev){
+            if(isset($revlist[$rev]) && $this->isRevisionApproved($rev, $id)){
+                return false;
+            }
         }
 
         $allowedGroups = array_filter(explode(' ', trim($this->getConf('author groups'))));

--- a/helper.php
+++ b/helper.php
@@ -193,7 +193,7 @@ class helper_plugin_publish extends DokuWiki_Plugin {
         }
 
         static $sortedApprovedRevisions = array();
-        if (!isset($sortedApprovedRevisions[$id])) {
+        if (!isset($sortedApprovedRevisions[$id]) || defined('DOKU_UNITTEST')) {
             $approvals = $this->getApprovals($id);
             krsort($approvals);
             $sortedApprovedRevisions[$id] = $approvals;


### PR DESCRIPTION
This is a more well-organized patch replacing PR #98, after tests are split and carefully compared between code branches.

To sum up what these commits do:

1. Add basic "show expected version" tests. They were written based on definitions at https://www.dokuwiki.org/plugin:publish#display_revision. And [it failed](https://travis-ci.org/phy25/dokuwiki-plugin-publish/builds/321428408) because:

> There were 2 failures:
> 1) approvel_test::test_show_expected_revision
> Visiting a draft revision with AUTH_READ did not return draft content.
> Failed asserting that false is true.
> /home/travis/build/phy25/dokuwiki-plugin-publish/lib/plugins/publish/_test/publish.test.php:267
> 2) approvel_test::test_show_expected_revision_hide_drafts
> Visiting a draft revision with hide_drafts on did not return in denied mode.
> Failed asserting that false is true.
> /home/travis/build/phy25/dokuwiki-plugin-publish/lib/plugins/publish/_test/publish.test.php:286
>
> FAILURES!
> Tests: 36, Assertions: 104, Failures: 2.

2. Fix "visiting a draft revision with AUTH_READ did not return draft content", In the test case it is showing the latest version (redirected). So don't redirect to the latest revision if [specific] [draft] revision is requested. After these commits, [tests error reduced](https://travis-ci.org/phy25/dokuwiki-plugin-publish/builds/321430856):

> There was 1 failure:
> 1) approvel_test::test_show_expected_revision_hide_drafts
> Visiting a draft revision with hide_drafts on did not return in denied mode.
> Failed asserting that false is true.
> /home/travis/build/phy25/dokuwiki-plugin-publish/lib/plugins/publish/_test/publish.test.php:286
> 
> FAILURES!
> Tests: 36, Assertions: 104, Failures: 1.

3. Fix "visiting a draft revision with hide_drafts on did not return in denied mode". Here we have to detect user permission based on REV instead of ID, because of the "hide drafts" feature. The code is somewhat inefficient indeed because I tried to keep consistence of the function usage in old parts of the code, so this may be optimized later.
Whatever, [it works](https://travis-ci.org/phy25/dokuwiki-plugin-publish/builds/321433518).

> OK (36 tests, 105 assertions)
