### PR TITLE
Fix dropping meta creator

### DIFF
--- a/_test/mail.unit.test.php
+++ b/_test/mail.unit.test.php
@@ -48,13 +48,13 @@ class publish_mail_unit_test extends DokuWikiTest {
         global $USERINFO;
         $_SERVER['REMOTE_USER'] = 'john';
         $USERINFO['name'] = 'John Smith';
-        saveWikiText('start', 'start first', 'foobar');
+        saveWikiText('start', 'start first', 'summary of save 1');
         $oldrevision = pageinfo();
         $oldrevision = $oldrevision['lastmod'];
-        sleep(1);
+        $this->waitForTick(true);
         global $INFO;
         $INFO = pageinfo();
-        saveWikiText('start', 'start second', 'foobar');
+        saveWikiText('start', 'start second', 'summary of save 2');
         $newrevision = pageinfo();
         $newrevision = $newrevision['lastmod'];
 
@@ -67,7 +67,7 @@ IP-Address       : @IPADDRESS@
 Hostname         : @HOSTNAME@
 Previous Revision: http://wiki.example.com' . DOKU_BASE . 'doku.php?id=start&rev=' . $oldrevision . '
 New Revision     : http://wiki.example.com' . DOKU_BASE . 'doku.php?id=start&rev=' . $newrevision . '
-Edit Summary     : foobar
+Edit Summary     : summary of save 2
 User             : @USER@
 
 http://wiki.example.com' . DOKU_BASE . 'doku.php?id=start&do=diff&rev2[0]=' . $oldrevision . '&rev2[1]=' . $newrevision . '&difftype=sidebyside

--- a/_test/mail.unit.test.php
+++ b/_test/mail.unit.test.php
@@ -52,6 +52,8 @@ class publish_mail_unit_test extends DokuWikiTest {
         $oldrevision = pageinfo();
         $oldrevision = $oldrevision['lastmod'];
         sleep(1);
+        global $INFO;
+        $INFO = pageinfo();
         saveWikiText('start', 'start second', 'foobar');
         $newrevision = pageinfo();
         $newrevision = $newrevision['lastmod'];
@@ -100,6 +102,9 @@ http://wiki.example.com' . DOKU_BASE . '
         $auth->createUser('john','x','John Smith','abc@def.gh');
         $_SERVER['REMOTE_USER'] = 'john';
         $USERINFO['name'] = 'John Smith';
+
+        global $INFO;
+        $INFO = pageinfo();
         saveWikiText('start', 'start first', 'foobar');
 
         $_SERVER['REMOTE_USER'] = 'mike';

--- a/action/mail.php
+++ b/action/mail.php
@@ -40,7 +40,6 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
         global $ACT;
         global $INFO;
         global $conf;
-        $data = pageinfo();
 
         if ($ACT != 'save') {
             return true;
@@ -71,7 +70,7 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
         }
 
         // get mail sender
-        $ReplyTo = $data['userinfo']['mail'];
+        $ReplyTo = $INFO['userinfo']['mail'];
 
         if ($ReplyTo == $receiver) {
             return true;
@@ -82,7 +81,7 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
         }
 
         // get mail subject
-        $timestamp = dformat($data['lastmod'], $conf['dformat']);
+        $timestamp = dformat(filemtime(wikiFN($ID)), $conf['dformat']);
         $subject = $this->getLang('apr_mail_subject') . ': ' . $ID . ' - ' . $timestamp;
 
         $body = $this->create_mail_body('change');
@@ -106,16 +105,16 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
     public function create_mail_body($action) {
         global $ID;
         global $conf;
-        $pageinfo = pageinfo();
+        global $INFO;
 
         // get mail text
-        $rev = $pageinfo['lastmod'];
+        $rev = filemtime(wikiFN($ID));
 
         if ($action === 'change') {
             $body = io_readFile($this->localFN('mailchangetext'));
 
             //If there is no approved revision show the diff to the revision before. Otherwise show the diff to the last approved revision.
-            if($this->hlp->hasApprovals($pageinfo['meta'])) {
+            if($this->hlp->hasApprovals($INFO['meta'])) {
                 $aprpre = 'Aproved';
                 $oldrev = $this->hlp->getLatestApprovedRevision($ID);
                 $difflink = $this->hlp->getDifflink($ID, $oldrev, $rev);
@@ -128,7 +127,7 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
 
             $body = str_replace('@DIFF@', $difflink, $body);
             $body = str_replace('@APRPRE@', $aprpre, $body);
-            $summary = $pageinfo['meta']['last_change']['sum'];
+            $summary = $INFO['meta']['last_change']['sum'];
             $body = str_replace('@SUMMARY@', $summary, $body);
             if ($oldrev === false ) {
                 $oldlink = '---';


### PR DESCRIPTION
Calling pageinfo() durint IO_WIKIPAGE_WRITE of newly created pages caused the page's metadata file to be written prematurely which in turn caused the creator to be omitted from the page's metadata.

This reworks the create_mail_body action to no longer call pageinfo().

See also splitbrain/dokuwiki#2401