### PR TITLE
Consitant naming to allow people find the addon in the extension manager

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base    publish
 author  Jarrod Lowe, Andreas Gohr, Dominik Eckelmann
 email   dokuwiki@cosmocode.de
 date    2018-05-23
-name    Publishing Plugin
+name    Publish Plugin
 desc    Integrate a publishing process into DokuWiki
 url     http://www.dokuwiki.org/plugin:publish


### PR DESCRIPTION
Hi,

just found out during a debugging session of my plugin that the naming is inconsistent. The change will ensure proper naming the extension manager list to allow others to find the plugin using the "Search and Install" function.

Regards,

Andi