### PR TITLE
Implementing a weighted approval system

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -3,6 +3,7 @@
 $conf['apr_namespaces'] = '';
 $conf['no_apr_namespaces'] = '';
 $conf['number_of_approved'] = 1;
+$conf['approving_weights'] = '';
 $conf['hidereaderbanner'] = 0;
 $conf['hide drafts'] = 0;
 $conf['hide_approved_banner'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,6 +3,7 @@
 $meta['apr_namespaces'] = array('string');
 $meta['no_apr_namespaces'] = array('string');
 $meta['number_of_approved'] = array('numeric', '_min' => 1);
+$meta['approving_weights'] = array('string', '_pattern' => '#^(\w+=\d+&?)*$#');
 $meta['hide drafts'] = array('onoff');
 $meta['hidereaderbanner'] = array('onoff');
 $meta['hide_approved_banner'] = array('onoff');

--- a/helper.php
+++ b/helper.php
@@ -99,7 +99,21 @@ class helper_plugin_publish extends DokuWiki_Plugin {
             return false;
         }
 
-        return ($INFO['perm'] >= AUTH_DELETE);
+        if ($INFO['perm'] >= AUTH_DELETE) {
+            return true;
+        }
+
+        if (empty($INFO['userinfo']['grps'])) {
+            return false;
+        }
+
+        $approving_weights = $this->getApprovingWeights();
+        if ($approving_weights) {
+            $approving_groups = array_keys($approving_weights);
+            return !!array_intersect($approving_groups, $INFO['userinfo']['grps']);
+        }
+
+        return false;
     }
 
     function getRevision($id = null) {
@@ -207,7 +221,52 @@ class helper_plugin_publish extends DokuWiki_Plugin {
         if (!isset($approvals[$revision])) {
             return false;
         }
-        return (count($approvals[$revision]) >= $this->getConf('number_of_approved'));
+
+        $number_of_approved = $this->getConf('number_of_approved');
+        if (count($approvals[$revision]) >= $number_of_approved) {
+            return true;
+        }
+
+        $approving_weights = $this->getApprovingWeights();
+        if (!$approving_weights) {
+            return false;
+        }
+
+        global $auth;
+        foreach ($approvals[$revision] as $username => $approver) {
+            $userdata = $auth->getUserData($username);
+            if (empty($userdata['grps'])) {
+                continue;
+            }
+
+            foreach ($approving_weights as $approving_group => $approving_weight) {
+                if (in_array($approving_group, $userdata['grps'], true)) {
+                    $number_of_approved -= $approving_weight;
+                    if ($number_of_approved <= 0) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @staticvar array $weights
+     * @return array
+     */
+    private function getApprovingWeights() {
+        static $weights = null;
+        if ($weights === null) {
+            $qs = $this->getConf('approving_weights');
+            if ($qs) {
+                parse_str($qs, $weights);
+                $weights = array_filter(array_map('intval', $weights));
+            } else {
+                $weights = [];
+            }
+        }
+        return $weights;
     }
 
     function isCurrentRevisionApproved($id = null) {

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,6 +3,7 @@
 $lang['apr_namespaces'] = 'Namespaces this plugin applies to (space separated list).';
 $lang['no_apr_namespaces'] = 'Namespaces this plugin <strong>does not</strong> apply to (space separated list).';
 $lang['number_of_approved'] = 'Number of users needed to approve a page.';
+$lang['approving_weights'] = 'Groups and the number of approvals required to approve a page (for example, if <i>number_of_approved=10</i> and this option is defined as <i>admin=10&moderator=5&user=1</i>, then a page can be approved by one admin, two moderators, ten users, or one moderator and five users)';
 $lang['hidereaderbanner'] = 'Hide banner to read only users';
 $lang['hide drafts'] = 'Hide drafts to read only users';
 $lang['hide_approved_banner']  = 'Hide banner on approved pages';


### PR DESCRIPTION
At this moment, only `AUTH_DELETE` or `AUTH_ADMIN` can approve pages. My idea is to create a more flexible approval system by allowing the administrator to indicate which groups can approve pages, and what their weight is.

For example, if `number_of_approved=10`, thanks to this system a page can be approved by:
- One admin;
- Two moderators;
- Ten users;
- Or, one moderator and five users.

The value for the `approving_weights` option should be specified as query string (for example, the scenario above corresponds to `admin=10&moderator=5&user=1`). To avoid mistakes, the value is validated by a regular expression ([conf/metadata.php:5](https://github.com/kondurake/dokuwiki-plugin-publish/blob/491eb0a4dc07d265bec1877cd6962a77b0893942/conf/metadata.php#L6)), while invalid values are ignored ([helper.php:264](https://github.com/kondurake/dokuwiki-plugin-publish/blob/491eb0a4dc07d265bec1877cd6962a77b0893942/helper.php#L264)).

Theoretically, my commits should not affect old behavior (see [helper.php:102](https://github.com/kondurake/dokuwiki-plugin-publish/blob/491eb0a4dc07d265bec1877cd6962a77b0893942/helper.php#L102) and [helper.php:226](https://github.com/kondurake/dokuwiki-plugin-publish/blob/491eb0a4dc07d265bec1877cd6962a77b0893942/helper.php#L226)). And of course, if the `approving_weights` option is not specified, everything will remain as before. However, I am new to Dokuwiki and I can make any mistakes. So please double check my commits and let me know if I missed something or you have any questions.

---
**Testing environment**
- PHP: 5.6.0
- Dokuwiki: 2018-04-22b "Greebo"
- Publish Plugin: 2019-01-10