### PR TITLE
Use DokuWiki's mail_isvalid to validate email address

### DIFF
--- a/action/banner.php
+++ b/action/banner.php
@@ -87,10 +87,8 @@ class action_plugin_publish_banner extends DokuWiki_Action_Plugin {
 
         global $INFO;
         if ($this->getConf('apr_mail_receiver') !== '' && $INFO['isadmin']) {
-            $validator                      = new EmailAddressValidator();
-            $validator->allowLocalAddresses = true;
             $addr = $this->getConf('apr_mail_receiver');
-            if(!$validator->check_email_address($addr)) {
+            if(!mail_isvalid($addr)) {
                 msg(sprintf($this->getLang('mail_invalid'),htmlspecialchars($addr)),-1);
             }
 

--- a/action/mail.php
+++ b/action/mail.php
@@ -62,10 +62,8 @@ class action_plugin_publish_mail extends DokuWiki_Action_Plugin {
 
         // get mail receiver
         $receiver = $this->getConf('apr_mail_receiver');
-        $validator                      = new EmailAddressValidator();
-        $validator->allowLocalAddresses = true;
-        if(!$validator->check_email_address($receiver)) {
-            dbglog(sprintf($this->getLang('mail_invalid'),htmlspecialchars($receiver)));
+        if(!mail_isvalid($receiver)) {
+            dbglog(sprintf($this->getLang('mail_invalid'), htmlspecialchars($receiver)));
             return false;
         }
 


### PR DESCRIPTION
This avoids direct use of `EmailAddressValidator`, where error occurred when EmailAddressValidator changed its implementation.

> Fatal error: Uncaught Error: Call to undefined method EmailAddressValidator::check_email_address() in lib/plugins/publish/action/banner.php:93 Stack trace: #0

This fixes #119. This also fixes #126, 